### PR TITLE
Settings: disable automatic ota update

### DIFF
--- a/src/com/android/settings/DevelopmentSettings.java
+++ b/src/com/android/settings/DevelopmentSettings.java
@@ -984,7 +984,7 @@ public class DevelopmentSettings extends RestrictedSettingsFragment
         // automatic update is enabled.
         updateSwitchPreference(mOtaDisableAutomaticUpdate, Settings.Global.getInt(
                 getActivity().getContentResolver(),
-                Settings.Global.OTA_DISABLE_AUTOMATIC_UPDATE, 0) != 1);
+                Settings.Global.OTA_DISABLE_AUTOMATIC_UPDATE, 1) != 1);
     }
 
     private void writeOtaDisableAutomaticUpdateOptions() {


### PR DESCRIPTION
* somehow this piece of shit can erase the recovery partition on G3.

disable it by default